### PR TITLE
Cleaned up, refactored

### DIFF
--- a/BigDemo_S2D.ps1
+++ b/BigDemo_S2D.ps1
@@ -1,18 +1,18 @@
 ﻿<#
-Created:	 2017-01-02
-Version:	 1.0
-Author       Dave Kawula MVP and Thomas Rayner MVP
-Homepage:    http://www.checkyourlogs.net
+    Created:	 2017-01-02
+    Version:	 1.0
+    Author       Dave Kawula MVP and Thomas Rayner MVP
+    Homepage:    http://www.checkyourlogs.net
 
-Disclaimer:
-This script is provided "AS IS" with no warranties, confers no rights and 
-is not supported by the authors or DeploymentArtist.
+    Disclaimer:
+    This script is provided "AS IS" with no warranties, confers no rights and 
+    is not supported by the authors or DeploymentArtist.
 
-Author - Dave Kawula
+    Author - Dave Kawula
     Twitter: @DaveKawula
     Blog   : http://www.checkyourlogs.net
 
-Author - Thomas Rayner
+    Author - Thomas Rayner
     Twitter: @MrThomasRayner
     Blog   : http://workingsysadmin.com
 
@@ -56,48 +56,52 @@ Author - Thomas Rayner
 [cmdletbinding()]
 param
 ( 
-    [Parameter(Mandatory)]
-    [ValidateScript({ $_ -match '[^\\]$' })] #ensure WorkingDir does not end in a backslash, otherwise issues are going to come up below
-    [string]
-    $WorkingDir = 'c:\ClusterStoreage\Volume1\DCBuild',
+  [Parameter(Mandatory)]
+  [ValidateScript({
+        $_ -match '[^\\]$' 
+  })] #ensure WorkingDir does not end in a backslash, otherwise issues are going to come up below
+  [string]
+  $WorkingDir = 'c:\ClusterStoreage\Volume1\DCBuild',
 
-    [Parameter(Mandatory)]
-    [string]
-    $Organization = 'MVP Rockstars',
+  [Parameter(Mandatory)]
+  [string]
+  $Organization = 'MVP Rockstars',
 
-    [Parameter(Mandatory)]
-    [string]
-    $Owner = 'Dave Kawula',
+  [Parameter(Mandatory)]
+  [string]
+  $Owner = 'Dave Kawula',
 
-    [Parameter(Mandatory)]
-    [ValidateScript({ $_ -in ([System.TimeZoneInfo]::GetSystemTimeZones()).ID })] #ensure a valid TimeZone was passed
-    [string]
-    $Timezone = 'Pacific Standard Time',
+  [Parameter(Mandatory)]
+  [ValidateScript({
+        $_ -in ([System.TimeZoneInfo]::GetSystemTimeZones()).ID 
+  })] #ensure a valid TimeZone was passed
+  [string]
+  $Timezone = 'Pacific Standard Time',
 
-    [Parameter(Mandatory)]
-    [string]
-    $adminPassword = 'P@ssw0rd',
+  [Parameter(Mandatory)]
+  [string]
+  $adminPassword = 'P@ssw0rd',
 
-    [Parameter(Mandatory)]
-    [string]
-    $domainName = 'MVPDays.Com',
+  [Parameter(Mandatory)]
+  [string]
+  $domainName = 'MVPDays.Com',
 
-    [Parameter(Mandatory)]
-    [string]
-    $domainAdminPassword = 'P@ssw0rd',
+  [Parameter(Mandatory)]
+  [string]
+  $domainAdminPassword = 'P@ssw0rd', # This is not a preferred way to do passwords.
 
-    [Parameter(Mandatory)]
-    [string]
-    $virtualSwitchName = 'Dave MVP Demo',
+  [Parameter(Mandatory)]
+  [string]
+  $virtualSwitchName = 'Dave MVP Demo',
 
-    [Parameter(Mandatory)]
-    [ValidatePattern('(\d{1,3}\.){3}')] #ensure that Subnet is formatted like the first three octets of an IPv4 address
-    [string]
-    $Subnet = '172.16.200.',
+  [Parameter(Mandatory)]
+  [ValidatePattern('(\d{1,3}\.){3}')] #ensure that Subnet is formatted like the first three octets of an IPv4 address
+  [string]
+  $Subnet = '172.16.200.',
 
-    [Parameter(Mandatory)]
-    [string]
-    $ExtraLabfilesSource = 'C:\ClusterStorage\Volume1\DCBuild\Extralabfiles'
+  [Parameter(Mandatory)]
+  [string]
+  $ExtraLabfilesSource = 'C:\ClusterStorage\Volume1\DCBuild\Extralabfiles'
 
 
 )
@@ -106,391 +110,333 @@ param
 
 function Wait-PSDirect
 {
-     param
-     (
-         [string]
-         $VMName,
+  param
+  (
+    [string]
+    $VMName,
 
-         [Object]
-         $cred
-     )
+    [Object]
+    $cred
+  )
 
-    Write-Log $VMName "Waiting for PowerShell Direct (using $($cred.username))"
-    while ((Invoke-Command -VMName $VMName -Credential $cred {
-                'Test'
-    } -ea SilentlyContinue) -ne 'Test') 
-    {
-        Start-Sleep -Seconds 1
-    }
+  Write-Log $VMName "Waiting for PowerShell Direct (using $($cred.username))"
+  while ((Invoke-Command -VMName $VMName -Credential $cred {
+        'Test'
+  } -ea SilentlyContinue) -ne 'Test') 
+  {
+    Start-Sleep -Seconds 1
+  }
 }
 
 
-Function Wait-Sleep {
-	param (
-		[int]$sleepSeconds = 60,
-		[string]$title = "... Waiting for $sleepSeconds Seconds... Be Patient",
-		[string]$titleColor = "Yellow"
-	)
-	Write-Host -ForegroundColor $titleColor $title
-	for ($sleep = 1; $sleep -le $sleepSeconds; $sleep++ ) {
-		Write-Progress -ParentId -1 -Id 42 -Activity "Sleeping for $sleepSeconds seconds" -Status "Slept for $sleep Seconds:" -percentcomplete (($sleep / $sleepSeconds) * 100)
-		Start-Sleep 1
-	}
-    Write-Progress -Completed -Id 42 -Activity "Done Sleeping"
-    }
+function Wait-Sleep 
+{
+  param (
+    [int]$sleepSeconds = 60
+  )
+  
+  Write-Log "Waiting for $sleepSeconds seconds"
+
+  for ($sleep = 1; $sleep -le $sleepSeconds; $sleep++ ) 
+  {
+    Write-Progress -ParentId -1 -Id 42 -Activity "Sleeping for $sleepSeconds seconds" -Status "Slept for $sleep Seconds:" -PercentComplete (($sleep / $sleepSeconds) * 100)
+    Start-Sleep -Seconds 1
+  }
+  Write-Progress -Completed -Id 42 -Activity 'Done Sleeping'
+}
     
 
 function Restart-DemoVM
 {
-     param
-     (
-         [string]
-         $VMName
-     )
+  param
+  (
+    [string]$VMName
+  )
 
-    Write-Log $VMName 'Rebooting'
-    stop-vm $VMName
-    start-vm $VMName
+  Write-Log $VMName 'Rebooting'
+  Stop-VM $VMName
+  Start-VM $VMName
 }
 
 function Confirm-Path
 {
-    param
-    (
-        [string] $path
-    )
-    if (!(Test-Path $path)) 
-    {
-        $null = mkdir $path
-    }
+  param
+  (
+    [string] $Location
+  )
+  
+  if (!(Test-Path $Location)) 
+  {
+    $null = New-Item -Type Directory -Path $Location
+  }
 }
 
 function Write-Log 
 {
-    param
-    (
-        [string]$systemName,
-        [string]$message
-    )
+  param
+  (
+    [string]$systemName,
+    [string]$message
+  )
 
-    Write-Host -Object (Get-Date).ToShortTimeString() -ForegroundColor Cyan -NoNewline
-    Write-Host -Object ' - [' -ForegroundColor White -NoNewline
-    Write-Host -Object $systemName -ForegroundColor Yellow -NoNewline
-    Write-Host -Object "]::$($message)" -ForegroundColor White
+  Write-Object "[$(Get-Date -format T)] - [$systemName]::$($message)"
 }
 
 function Clear-File
 {
-    param
-    (
-        [string] $file
-    )
+  param
+  (
+    [string] $file
+  )
     
-    if (Test-Path $file) 
-    {
-        $null = Remove-Item $file -Recurse
-    }
+  if (Test-Path $file) 
+  {
+    $null = Remove-Item $file -Recurse -Force
+  }
 }
 
 function Get-UnattendChunk 
 {
-    param
-    (
-        [string] $pass, 
-        [string] $component, 
-        [xml] $unattend
-    ) 
+  param
+  (
+    [string] $pass, 
+    [string] $component, 
+    [xml] $unattend
+  ) 
     
-    return $unattend.unattend.settings |
-    Where-Object -Property pass -EQ -Value $pass `
-    |
-    Select-Object -ExpandProperty component `
-    |
+  $unattend.unattend.settings |
+    Where-Object -Property pass -EQ -Value $pass |
+    Select-Object -ExpandProperty component |
     Where-Object -Property name -EQ -Value $component
 }
 
 function New-UnattendFile 
 {
-    param
-    (
-        [string] $filePath
-    ) 
+  param
+  (
+    [string] $filePath
+  ) 
 
-    # Reload template - clone is necessary as PowerShell thinks this is a "complex" object
-    $unattend = $unattendSource.Clone()
-     
-    # Customize unattend XML
-    Get-UnattendChunk 'specialize' 'Microsoft-Windows-Shell-Setup' $unattend | ForEach-Object -Process {
-        $_.RegisteredOrganization = 'Azure Sea Class Covert Trial' #TR-Egg
-    }
-    Get-UnattendChunk 'specialize' 'Microsoft-Windows-Shell-Setup' $unattend | ForEach-Object -Process {
-        $_.RegisteredOwner = 'Thomas Rayner - @MrThomasRayner - workingsysadmin.com' #TR-Egg
-    }
-    Get-UnattendChunk 'specialize' 'Microsoft-Windows-Shell-Setup' $unattend | ForEach-Object -Process {
-        $_.TimeZone = $Timezone
-    }
-    Get-UnattendChunk 'oobeSystem' 'Microsoft-Windows-Shell-Setup' $unattend | ForEach-Object -Process {
-        $_.UserAccounts.AdministratorPassword.Value = $adminPassword
-    }
-    Get-UnattendChunk 'specialize' 'Microsoft-Windows-Shell-Setup' $unattend | ForEach-Object -Process {
-        $_.ProductKey = $WindowsKey
-    }
+  $unattend = $unattendSource.Clone()
+  Get-UnattendChunk 'specialize' 'Microsoft-Windows-Shell-Setup' $unattend | ForEach-Object -Process {
+    $_.RegisteredOrganization = 'Azure Sea Class Covert Trial' #TR-Egg
+    $_.RegisteredOwner = 'Thomas Rayner - @MrThomasRayner - workingsysadmin.com' #TR-Egg
+    $_.TimeZone = $Timezone
+    $_.ProductKey = $WindowsKey
+  }
+  Get-UnattendChunk 'oobeSystem' 'Microsoft-Windows-Shell-Setup' $unattend | ForEach-Object -Process {
+    $_.UserAccounts.AdministratorPassword.Value = $adminPassword
+  }
 
-    Clear-File $filePath
-    $unattend.Save($filePath)
+  Clear-File $filePath
+  $unattend.Save($filePath)
 }
 
-Function Initialize-BaseImage
+function Initialize-BaseImage
 {
-
-
-
-    Mount-DiskImage $ServerISO
-    $DVDDriveLetter = (Get-DiskImage $ServerISO | Get-Volume).DriveLetter
-    Copy-Item -Path "$($DVDDriveLetter):\NanoServer\NanoServerImageGenerator\Convert-WindowsImage.ps1" -Destination "$($WorkingDir)\Convert-WindowsImage.ps1" -Force
-    Import-Module -Name "$($DVDDriveLetter):\NanoServer\NanoServerImagegenerator\NanoServerImageGenerator.psm1" -Force
+  Mount-DiskImage $ServerISO
+  $DVDDriveLetter = (Get-DiskImage $ServerISO | Get-Volume).DriveLetter
+  Copy-Item -Path "$($DVDDriveLetter):\NanoServer\NanoServerImageGenerator\Convert-WindowsImage.ps1" -Destination "$($WorkingDir)\Convert-WindowsImage.ps1" -Force
+  Import-Module -Name "$($DVDDriveLetter):\NanoServer\NanoServerImagegenerator\NanoServerImageGenerator.psm1" -Force
    
    
-            if (!(Test-Path "$($BaseVHDPath)\NanoBase.vhdx")) 
-            {
-            New-NanoServerImage -MediaPath "$($DVDDriveLetter):\" -BasePath $BaseVHDPath -TargetPath "$($BaseVHDPath)\NanoBase.vhdx" -Edition Standard -DeploymentType Guest -Compute -Clustering -AdministratorPassword (ConvertTo-SecureString $adminPassword -AsPlainText -Force)
-           # New-NanoServerImage -MediaPath "$($DVDDriveLetter):\" -BasePath $BaseVDHPath -TargetPath "$($BaseVHDPath)\NanoBase.vhdx" -GuestDrivers -DeploymentType Guest -Edition Standard -Compute -Clustering -Defender -Storage -AdministratorPassword (ConvertTo-SecureString $adminPassword -AsPlainText -Force)
-
-            
-            }
+  if (!(Test-Path -Path "$($BaseVHDPath)\NanoBase.vhdx")) 
+  {
+    New-NanoServerImage -MediaPath "$($DVDDriveLetter):\" -BasePath $BaseVHDPath -TargetPath "$($BaseVHDPath)\NanoBase.vhdx" -Edition Standard -DeploymentType Guest -Compute -Clustering -AdministratorPassword (ConvertTo-SecureString -String $adminPassword -AsPlainText -Force)
+  }
     
+  New-UnattendFile "$WorkingDir\unattend.xml"
 
-    #Copy-Item -Path '$WorkingDir\Convert-WindowsImage.ps1' -Destination "$($WorkingDir)\Convert-WindowsImage.ps1" -Force
-    New-UnattendFile "$WorkingDir\unattend.xml"
+  if (!(Test-Path -Path "$($BaseVHDPath)\VMServerBaseCore.vhdx")) 
+  {
+    Set-Location $WorkingDir 
 
+    . .\Convert-WindowsImage.ps1 
+    $ConvertWindowsImageParam = @{
+      SourcePath          = $ServerISO
+      RemoteDesktopEnable = $True
+      Passthru            = $True
+      Edition             = 'ServerDataCenterCore'
+      VHDFormat           = 'VHDX'
+      SizeBytes           = 60GB
+      WorkingDirectory    = $WorkingDir
+      VHDPath             = "$($BaseVHDPath)\VMServerBaseCore.vhdx"
+      DiskLayout          = 'UEFI'
+      UnattendPath        = "$($WorkingDir)\unattend.xml"
+    }
 
-    #Build the Windows 2016 Core Base VHDx for the Lab
+    $VHDx = Convert-WindowsImage @ConvertWindowsImageParam
+  }
     
-            if (!(Test-Path "$($BaseVHDPath)\VMServerBaseCore.vhdx")) 
-                        {
+  if (!(Test-Path -Path "$($BaseVHDPath)\VMServerBase.vhdx")) 
+  {
+    Set-Location $WorkingDir 
+
+    . .\Convert-WindowsImage.ps1 
+    $ConvertWindowsImageParam = @{
+      SourcePath          = $ServerISO
+      RemoteDesktopEnable = $True
+      Passthru            = $True
+      Edition             = 'ServerDataCenter'
+      VHDFormat           = 'VHDX'
+      SizeBytes           = 60GB
+      WorkingDirectory    = $WorkingDir
+      VHDPath             = "$($BaseVHDPath)\VMServerBase.vhdx"
+      DiskLayout          = 'UEFI'
+      UnattendPath        = "$($WorkingDir)\unattend.xml"
+    }
+
+    $VHDx = Convert-WindowsImage @ConvertWindowsImageParam
+  }
             
-
-            Set-Location $workingdir 
-
-            # Load (aka "dot-source) the Function 
-            . .\Convert-WindowsImage.ps1 
-            # Prepare all the variables in advance (optional) 
-            $ConvertWindowsImageParam = @{  
-                SourcePath          = $ServerISO
-                RemoteDesktopEnable = $True  
-                Passthru            = $True  
-                Edition    = "ServerDataCenterCore"
-                VHDFormat = "VHDX"
-                SizeBytes = 60GB
-                WorkingDirectory = $workingdir
-                VHDPath = "$($BaseVHDPath)\VMServerBaseCore.vhdx"
-                DiskLayout = 'UEFI'
-                UnattendPath = "$($workingdir)\unattend.xml" 
-            }
-
-            $VHDx = Convert-WindowsImage @ConvertWindowsImageParam
-
-            }
-
-
-            #Build the Windows 2016 Full UI Base VHDx for the Lab
-    
-            if (!(Test-Path "$($BaseVHDPath)\VMServerBase.vhdx")) 
-                        {
-            
-
-            Set-Location $workingdir 
-
-            # Load (aka "dot-source) the Function 
-            . .\Convert-WindowsImage.ps1 
-            # Prepare all the variables in advance (optional) 
-            $ConvertWindowsImageParam = @{  
-                SourcePath          = $ServerISO
-                RemoteDesktopEnable = $True  
-                Passthru            = $True  
-                Edition    = "ServerDataCenter"
-                VHDFormat = "VHDX"
-                SizeBytes = 60GB
-                WorkingDirectory = $workingdir
-                VHDPath = "$($BaseVHDPath)\VMServerBase.vhdx"
-                DiskLayout = 'UEFI'
-                UnattendPath = "$($workingdir)\unattend.xml" 
-            }
-
-            $VHDx = Convert-WindowsImage @ConvertWindowsImageParam
-
-            }
-            
-    
-    Clear-File "$($BaseVHDPath)\unattend.xml"
-    Dismount-DiskImage $ServerISO 
-    Clear-File "$($WorkingDir)\Convert-WindowsImage.ps1"
-
+  Clear-File "$($BaseVHDPath)\unattend.xml"
+  Dismount-DiskImage $ServerISO 
+  Clear-File "$($WorkingDir)\Convert-WindowsImage.ps1"
 }
 
 function Invoke-DemoVMPrep 
 {
-    param
-    (
-        [string] $VMName, 
-        [string] $GuestOSName, 
-        [switch] $FullServer
-    ) 
+  param
+  (
+    [string] $VMName, 
+    [string] $GuestOSName, 
+    [switch] $FullServer
+  ) 
 
-    Write-Log $VMName 'Removing old VM'
-    get-vm $VMName -ErrorAction SilentlyContinue |
-    stop-vm -TurnOff -Force -Passthru |
-    remove-vm -Force
-    Clear-File "$($VMPath)\$($GuestOSName).vhdx"
+  Write-Log $VMName 'Removing old VM'
+    Get-VM $VMName -ErrorAction SilentlyContinue |
+    Stop-VM -TurnOff -Force -Passthru |
+    Remove-VM -Force
+  Clear-File "$($VMPath)\$($GuestOSName).vhdx"
    
-    Write-Log $VMName 'Creating new differencing disk'
-    if ($FullServer) 
-    {
-        $null = New-VHD -Path "$($VMPath)\$($GuestOSName).vhdx" -ParentPath "$($BaseVHDPath)\VMServerBase.vhdx" -Differencing
-    }
-
-    else 
-    {
-        $null = New-VHD -Path "$($VMPath)\$($GuestOSName).vhdx" -ParentPath "$($BaseVHDPath)\VMServerBaseCore.vhdx" -Differencing
-    }
-
-    Write-Log $VMName 'Creating virtual machine'
-    new-vm -Name $VMName -MemoryStartupBytes 4GB -SwitchName $virtualSwitchName `
-    -Generation 2 -Path "$($VMPath)\" | Set-VM -ProcessorCount 2 
-
-    Set-VMFirmware -VMName $VMName -SecureBootTemplate MicrosoftUEFICertificateAuthority
-    Set-VMFirmware -Vmname $VMName -EnableSecureBoot off
-    Add-VMHardDiskDrive -VMName $VMName -Path "$($VMPath)\$($GuestOSName).vhdx" -ControllerType SCSI
-    Write-Log $VMName 'Starting virtual machine'
-    Enable-VMIntegrationService -Name 'Guest Service Interface' -VMName $VMName
-    start-vm $VMName
-}
-
-function Create-DemoVM 
-{
-    param
-    (
-        [string] $VMName, 
-        [string] $GuestOSName, 
-        [string] $IPNumber = '0'
-    ) 
+  Write-Log $VMName 'Creating new differencing disk'
   
-    Wait-PSDirect $VMName -cred $localCred
+  $vhdxName = 'VMServerBaseCore.vhdx'
+  if ($FullServer)
+  {
+    $FullServer = VMServerBase.vhdx
+  }
+  
+  $null = New-VHD -Path "$($VMPath)\$($GuestOSName).vhdx" -ParentPath "$($BaseVHDPath)\$vhdxName" -Differencing
 
-    Invoke-Command -VMName $VMName -Credential $localCred {
-        param($IPNumber, $GuestOSName,  $VMName, $domainName, $Subnet)
-        if ($IPNumber -ne '0') 
-        {
-            Write-Output -InputObject "[$($VMName)]:: Setting IP Address to $($Subnet)$($IPNumber)"
-            $null = New-NetIPAddress -IPAddress "$($Subnet)$($IPNumber)" -InterfaceAlias 'Ethernet' -PrefixLength 24
-            Write-Output -InputObject "[$($VMName)]:: Setting DNS Address"
-            Get-DnsClientServerAddress | ForEach-Object -Process {
-                Set-DnsClientServerAddress -InterfaceIndex $_.InterfaceIndex -ServerAddresses "$($Subnet)1"
-            }
-        }
-        Write-Output -InputObject "[$($VMName)]:: Renaming OS to `"$($GuestOSName)`""
-        Rename-Computer -NewName $GuestOSName
-        Write-Output -InputObject "[$($VMName)]:: Configuring WSMAN Trusted hosts"
-        Set-Item -Path WSMan:\localhost\Client\TrustedHosts -Value "*.$($domainName)" -Force
-        Set-Item WSMan:\localhost\client\trustedhosts "$($Subnet)*" -Force -concatenate
-        Enable-WSManCredSSP -Role Client -DelegateComputer "*.$($domainName)" -Force
-    } -ArgumentList $IPNumber, $GuestOSName, $VMName, $domainName, $Subnet
+  Write-Log $VMName 'Creating virtual machine'
+  New-VM -Name $VMName -MemoryStartupBytes 4GB -SwitchName $virtualSwitchName -Generation 2 -Path "$($VMPath)\" |
+    Set-VM -ProcessorCount 2 
 
-    Restart-DemoVM $VMName
-    
-    Wait-PSDirect $VMName -cred $localCred
+  Set-VMFirmware -VMName $VMName -SecureBootTemplate MicrosoftUEFICertificateAuthority
+  Set-VMFirmware -Vmname $VMName -EnableSecureBoot off
+  Add-VMHardDiskDrive -VMName $VMName -Path "$($VMPath)\$($GuestOSName).vhdx" -ControllerType SCSI
+  Write-Log $VMName 'Starting virtual machine'
+  Enable-VMIntegrationService -Name 'Guest Service Interface' -VMName $VMName
+  Start-VM $VMName
 }
+
+function New-DemoVM 
+{
+  param
+  (
+    [string] $VMName, 
+    [string] $GuestOSName, 
+    [string] $IPNumber = '0'
+  ) 
+  
+  Wait-PSDirect $VMName -cred $localCred
+
+  Invoke-Command -VMName $VMName -Credential $localCred {
+    param($IPNumber, $GuestOSName,  $VMName, $domainName, $Subnet)
+    if ($IPNumber -ne '0') 
+    {
+      Write-Output -InputObject "[$($VMName)]::Setting IP Address to $($Subnet)$($IPNumber)"
+      $null = New-NetIPAddress -IPAddress "$($Subnet)$($IPNumber)" -InterfaceAlias 'Ethernet' -PrefixLength 24
+      Write-Output -InputObject "[$($VMName)]::Setting DNS Address"
+      Get-DnsClientServerAddress | ForEach-Object -Process {
+        Set-DnsClientServerAddress -InterfaceIndex $_.InterfaceIndex -ServerAddresses "$($Subnet)1"
+      }
+    }
+    Write-Output -InputObject "[$($VMName)]::Renaming OS to `"$($GuestOSName)`""
+    Rename-Computer -NewName $GuestOSName
+    Write-Output -InputObject "[$($VMName)]::Configuring WSMAN Trusted hosts"
+    Set-Item -Path WSMan:\localhost\Client\TrustedHosts -Value "*.$($domainName)" -Force
+    Set-Item WSMan:\localhost\client\trustedhosts "$($Subnet)*" -Force -concatenate
+    Enable-WSManCredSSP -Role Client -DelegateComputer "*.$($domainName)" -Force
+  } -ArgumentList $IPNumber, $GuestOSName, $VMName, $domainName, $Subnet
+
+  Restart-DemoVM $VMName
+    
+  Wait-PSDirect $VMName -cred $localCred
+}
+
+
 function Invoke-NodeStorageBuild 
 {
-    param($VMName, $GuestOSName)
+  param
+  (
+    [string]$VMName, 
+    [string]$GuestOSName
+  )
 
-    Create-DemoVM $VMName $GuestOSName
-    Clear-File "$($VMPath)\$($GuestOSName) - Data 1.vhdx"
-    Clear-File "$($VMPath)\$($GuestOSName) - Data 2.vhdx"
-    Get-VM $VMName | Stop-VM 
-    Add-VMNetworkAdapter -VMName $VMName -SwitchName $virtualSwitchName
-    new-vhd -Path "$($VMPath)\$($GuestOSName) - Data 1.vhdx" -Dynamic -SizeBytes 200GB 
-    Add-VMHardDiskDrive -VMName $VMName -Path "$($VMPath)\$($GuestOSName) - Data 1.vhdx" -ControllerType SCSI
-    new-vhd -Path "$($VMPath)\$($GuestOSName) - Data 2.vhdx" -Dynamic -SizeBytes 200GB
-    Add-VMHardDiskDrive -VMName $VMName -Path "$($VMPath)\$($GuestOSName) - Data 2.vhdx" -ControllerType SCSI
-    Set-VMProcessor -VMName $VMName -Count 2 -ExposeVirtualizationExtensions $true
-    Add-VMNetworkAdapter -VMName $VMName -SwitchName $virtualSwitchName
-    Add-VMNetworkAdapter -VMName $VMName -SwitchName $virtualSwitchName
-    Add-VMNetworkAdapter -VMName $VMName -SwitchName $virtualSwitchName
-    Get-VMNetworkAdapter -VMName $VMName | Set-VMNetworkAdapter -AllowTeaming On
-    Get-VMNetworkAdapter -VMName $VMName | Set-VMNetworkAdapter -MacAddressSpoofing on
-    Start-VM $VMName
-    Wait-PSDirect $VMName -cred $localCred
+  New-DemoVM $VMName $GuestOSName
+  Clear-File "$($VMPath)\$($GuestOSName) - Data 1.vhdx"
+  Clear-File "$($VMPath)\$($GuestOSName) - Data 2.vhdx"
+  Get-VM $VMName | Stop-VM 
+  Add-VMNetworkAdapter -VMName $VMName -SwitchName $virtualSwitchName
+  New-VHD -Path "$($VMPath)\$($GuestOSName) - Data 1.vhdx" -Dynamic -SizeBytes 200GB 
+  Add-VMHardDiskDrive -VMName $VMName -Path "$($VMPath)\$($GuestOSName) - Data 1.vhdx" -ControllerType SCSI
+  New-VHD -Path "$($VMPath)\$($GuestOSName) - Data 2.vhdx" -Dynamic -SizeBytes 200GB
+  Add-VMHardDiskDrive -VMName $VMName -Path "$($VMPath)\$($GuestOSName) - Data 2.vhdx" -ControllerType SCSI
+  Set-VMProcessor -VMName $VMName -Count 2 -ExposeVirtualizationExtensions $True
+  Add-VMNetworkAdapter -VMName $VMName -SwitchName $virtualSwitchName
+  Add-VMNetworkAdapter -VMName $VMName -SwitchName $virtualSwitchName
+  Add-VMNetworkAdapter -VMName $VMName -SwitchName $virtualSwitchName
+  Get-VMNetworkAdapter -VMName $VMName | Set-VMNetworkAdapter -AllowTeaming On
+  Get-VMNetworkAdapter -VMName $VMName | Set-VMNetworkAdapter -MacAddressSpoofing on
+  Start-VM $VMName
+  Wait-PSDirect $VMName -cred $localCred
 
-    Invoke-Command -VMName $VMName -Credential $localCred {
-        param($VMName, $domainCred, $domainName)
-        Write-Output -InputObject "[$($VMName)]:: Installing Clustering"
-        $null = Install-WindowsFeature -Name File-Services, Failover-Clustering, Hyper-V -IncludeManagementTools
-        Write-Output -InputObject "[$($VMName)]:: Joining domain as `"$($env:computername)`""
-        while (!(Test-Connection -ComputerName $domainName -BufferSize 16 -Count 1 -Quiet -ea SilentlyContinue)) 
-        {
-            Start-Sleep -Seconds 1
-        }
-        do 
-        {
-            Add-Computer -DomainName $domainName -Credential $domainCred -ea SilentlyContinue
-        }
-        until ($?)
-    } -ArgumentList $VMName, $domainCred, $domainName
+  Invoke-Command -VMName $VMName -Credential $localCred {
+    param($VMName, $domainCred, $domainName)
+    Write-Output -InputObject "[$($VMName)]:: Installing Clustering"
+    $null = Install-WindowsFeature -Name File-Services, Failover-Clustering, Hyper-V -IncludeManagementTools
+    Write-Output -InputObject "[$($VMName)]:: Joining domain as `"$($env:computername)`""
+    
+    while (!(Test-Connection -ComputerName $domainName -BufferSize 16 -Count 1 -Quiet -ea SilentlyContinue)) 
+    {
+      Start-Sleep -Seconds 1
+    }
+    
+    do 
+    {
+      Add-Computer -DomainName $domainName -Credential $domainCred -ea SilentlyContinue
+    }
+    until ($?)
+  } -ArgumentList $VMName, $domainCred, $domainName
 
-    Wait-PSDirect $VMName -cred $domainCred
+  Wait-PSDirect $VMName -cred $domainCred
 
-    Invoke-Command -VMName $VMName -Credential $domainCred {
-        Rename-NetAdapter -Name 'Ethernet' -NewName 'LOM-P0'
-    }
-    Invoke-Command -VMName $VMName -Credential $DomainCred {
-        Rename-NetAdapter -Name 'Ethernet 2' -NewName 'LOM-P1'
-    }
-    Invoke-Command -VMName $VMName -Credential $DomainCred {
-        Rename-NetAdapter -Name 'Ethernet 3' -NewName 'Riser-P0'
-    }
-    Invoke-Command -VMName $VMName -Credential $DomainCred{
-        Get-NetAdapter -Name 'Ethernet 5' | Rename-NetAdapter -NewName 'Riser-P1'
-    }
-    Invoke-Command -VMName $VMName -Credential $DomainCred {
-        New-NetLbfoTeam -Name HyperVTeam -TeamMembers 'LOM-P0' -verbose -confirm:$false
-    }
-    Invoke-Command -VMName $VMName -Credential $DomainCred {
-        Add-NetLbfoTeamMember 'LOM-P1' -team HyperVTeam -confirm:$false
-    }
-    Invoke-Command -VMName $VMName -Credential $DomainCred {
-        New-NetLbfoTeam -Name StorageTeam -TeamMembers 'Riser-P0' -verbose -confirm:$false
-    }
-    Invoke-Command -VMName $VMName -Credential $DomainCred {
-        Add-NetLbfoTeamMember 'Riser-P1' -team StorageTeam -confirm:$false
-    }
+  Invoke-Command -VMName $VMName -Credential $domainCred {
+    Rename-NetAdapter -Name 'Ethernet' -NewName 'LOM-P0'
+    Rename-NetAdapter -Name 'Ethernet 2' -NewName 'LOM-P1'
+    Rename-NetAdapter -Name 'Ethernet 3' -NewName 'Riser-P0'
+    Get-NetAdapter -Name 'Ethernet 5' | Rename-NetAdapter -NewName 'Riser-P1'
+    New-NetLbfoTeam -Name HyperVTeam -TeamMembers 'LOM-P0' -verbose -confirm:$false
+    Add-NetLbfoTeamMember 'LOM-P1' -team HyperVTeam -confirm:$false
+    New-NetLbfoTeam -Name StorageTeam -TeamMembers 'Riser-P0' -verbose -confirm:$false
+    Add-NetLbfoTeamMember 'Riser-P1' -team StorageTeam -confirm:$false
+  }
 
-    Restart-DemoVM $VMName
-    Wait-PSDirect $VMName -cred $domainCred
+  Restart-DemoVM $VMName
+  Wait-PSDirect $VMName -cred $domainCred
 
-    ping localhost -n 20
+  Test-Connection -ComputerName localhost -Count 20
 
-    Invoke-Command -VMName $VMName -Credential $domainCred {
-        New-VMSwitch -Name 'VSW01' -NetAdapterName 'HyperVTeam' -AllowManagementOS $false
-    }
-    Invoke-Command -VMName $VMName -Credential $domainCred {
-        Add-VMNetworkAdapter -ManagementOS -Name ClusterCSV-VLAN204 -Switchname VSW01 -verbose
-    }
-    Invoke-Command -VMName $VMName -Credential $domainCred {
-        Add-VMNetworkAdapter -ManagementOS -Name LM-VLAN203 -Switchname VSW01 -verbose
-    }
-    Invoke-Command -VMName $VMName -Credential $domainCred {
-        Add-VMNetworkAdapter -ManagementOS -Name Servers-VLAN201 -Switchname VSW01 -verbose
-    }
-    Invoke-Command -VMName $VMName -Credential $domainCred {
-        Add-VMNetworkAdapter -ManagementOS -Name MGMT-VLAN200 -Switchname VSW01 -verbose
-    }
-
-    # Restart-DemoVM $VMName
+  Invoke-Command -VMName $VMName -Credential $domainCred {
+    New-VMSwitch -Name 'VSW01' -NetAdapterName 'HyperVTeam' -AllowManagementOS $false
+    Add-VMNetworkAdapter -ManagementOS -Name ClusterCSV-VLAN204 -Switchname VSW01 -verbose
+    Add-VMNetworkAdapter -ManagementOS -Name LM-VLAN203 -Switchname VSW01 -verbose
+    Add-VMNetworkAdapter -ManagementOS -Name Servers-VLAN201 -Switchname VSW01 -verbose
+    Add-VMNetworkAdapter -ManagementOS -Name MGMT-VLAN200 -Switchname VSW01 -verbose
+  }
 }
-
-
-
 
 
 #endregion
@@ -499,20 +445,13 @@ function Invoke-NodeStorageBuild
 $BaseVHDPath = "$($WorkingDir)\BaseVHDs"
 $VMPath = "$($WorkingDir)\VMs"
 
-$localCred = New-Object -TypeName System.Management.Automation.PSCredential `
--ArgumentList 'Administrator', (ConvertTo-SecureString -String $adminPassword -AsPlainText -Force)
+$localCred = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'Administrator', (ConvertTo-SecureString -String $adminPassword -AsPlainText -Force)
 
-$domainCred = New-Object -TypeName System.Management.Automation.PSCredential `
--ArgumentList "$($domainName)\Administrator", (ConvertTo-SecureString -String $domainAdminPassword -AsPlainText -Force)
+$domainCred = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList "$($domainName)\Administrator", (ConvertTo-SecureString -String $domainAdminPassword -AsPlainText -Force)
 
-#$ServerISO = "D:\DCBuild\10586.0.151029-1700.TH2_RELEASE_SERVER_OEMRET_X64FRE_EN-US.ISO"
-#$ServerISO = "d:\DCBuild\14393.0.160808-1702.RS1_Release_srvmedia_SERVER_OEMRET_X64FRE_EN-US.ISO"
-#ServerISO = 'D:\DCBuild\en_windows_server_2016_technical_preview_5_x64_dvd_8512312.iso'
-$ServerISO = 'c:\ClusterStorage\Volume1\DCBuild\en_windows_server_2016_x64_dvd_9327751.iso' #Updated for RTM Build 2016
+$ServerISO = 'c:\ClusterStorage\Volume1\DCBuild\en_windows_server_2016_x64_dvd_9327751.iso'
 
-#$WindowsKey = "2KNJJ-33Y9H-2GXGX-KMQWH-G6H67"
-#$WindowsKey = '6XBNX-4JQGW-QX6QG-74P76-72V67'
-$WindowsKey = 'QJP9N-Q6RY7-VTP6Y-2MTF8-BWR7R' #Dave's Technet KEY Remove for Publishing of Book
+$WindowsKey = ''; throw 'You did not specify a Windows key. Remove this throw statement when you have.'
 
 $unattendSource = [xml]@"
 <?xml version="1.0" encoding="utf-8"?>
@@ -563,12 +502,12 @@ Write-Log 'Host' 'Building Base Images'
 
 if (!(Test-Path -Path "$($BaseVHDPath)\VMServerBase.vhdx")) 
 {
-    . Initialize-BaseImage
+  . Initialize-BaseImage
 }
 
 if ((Get-VMSwitch | Where-Object -Property name -EQ -Value $virtualSwitchName) -eq $null)
 {
-    New-VMSwitch -Name $virtualSwitchName -SwitchType Private
+  New-VMSwitch -Name $virtualSwitchName -SwitchType Private
 }
 
 Invoke-DemoVMPrep 'Domain Controller 1' 'DC1' -FullServer
@@ -576,74 +515,74 @@ Invoke-DemoVMPrep 'Domain Controller 2' 'DC2'-FullServer
 Invoke-DemoVMPrep 'DHCP Server' 'DHCP'-FullServer
 Invoke-DemoVMPrep 'Management Console' 'Management' -FullServer
 
-
 $VMName = 'Domain Controller 1'
 $GuestOSName = 'DC1'
 $IPNumber = '1'
 
-Create-DemoVM $VMName $GuestOSName $IPNumber
+New-DemoVM $VMName $GuestOSName $IPNumber
 
 Invoke-Command -VMName $VMName -Credential $localCred {
-    param($VMName, $domainName, $domainAdminPassword)
+  param($VMName, $domainName, $domainAdminPassword)
 
-    Write-Output -InputObject "[$($VMName)]:: Installing AD"
-    $null = Install-WindowsFeature AD-Domain-Services -IncludeManagementTools
-    Write-Output -InputObject "[$($VMName)]:: Enabling Active Directory and promoting to domain controller"
-    Install-ADDSForest -DomainName $domainName -InstallDNS -NoDNSonNetwork -NoRebootOnCompletion `
-    -SafeModeAdministratorPassword (ConvertTo-SecureString -String $domainAdminPassword -AsPlainText -Force) -confirm:$false
+  Write-Output -InputObject "[$($VMName)]:: Installing AD"
+  $null = Install-WindowsFeature AD-Domain-Services -IncludeManagementTools
+  Write-Output -InputObject "[$($VMName)]:: Enabling Active Directory and promoting to domain controller"
+  Install-ADDSForest -DomainName $domainName -InstallDNS -NoDNSonNetwork -NoRebootOnCompletion -SafeModeAdministratorPassword (ConvertTo-SecureString -String $domainAdminPassword -AsPlainText -Force) -confirm:$false
 } -ArgumentList $VMName, $domainName, $domainAdminPassword
 
 Restart-DemoVM $VMName 
-
 
 $VMName = 'DHCP Server'
 $GuestOSName = 'DHCP'
 $IPNumber = '3'
 
-Create-DemoVM $VMName $GuestOSName $IPNumber
+New-DemoVM $VMName $GuestOSName $IPNumber
 
 Invoke-Command -VMName $VMName -Credential $localCred {
-    param($VMName, $domainCred, $domainName)
-    Write-Output -InputObject "[$($VMName)]:: Installing DHCP"
-    $null = Install-WindowsFeature DHCP -IncludeManagementTools
-    Write-Output -InputObject "[$($VMName)]:: Joining domain as `"$($env:computername)`""
-    while (!(Test-Connection -ComputerName $domainName -BufferSize 16 -Count 1 -Quiet -ea SilentlyContinue)) 
-    {
-        Start-Sleep -Seconds 1
-    }
-    do 
-    {
-        Add-Computer -DomainName $domainName -Credential $domainCred -ea SilentlyContinue
-    }
-    until ($?)
+  param($VMName, $domainCred, $domainName)
+  Write-Output -InputObject "[$($VMName)]:: Installing DHCP"
+  $null = Install-WindowsFeature DHCP -IncludeManagementTools
+  Write-Output -InputObject "[$($VMName)]:: Joining domain as `"$($env:computername)`""
+  
+  while (!(Test-Connection -ComputerName $domainName -BufferSize 16 -Count 1 -Quiet -ea SilentlyContinue)) 
+  {
+    Start-Sleep -Seconds 1
+  }
+  
+  do 
+  {
+    Add-Computer -DomainName $domainName -Credential $domainCred -ea SilentlyContinue
+  }
+  until ($?)
 } -ArgumentList $VMName, $domainCred, $domainName
 
 Restart-DemoVM $VMName
 Wait-PSDirect $VMName -cred $domainCred
 
 Invoke-Command -VMName $VMName -Credential $domainCred {
-    param($VMName, $domainName, $Subnet, $IPNumber)
+  param($VMName, $domainName, $Subnet, $IPNumber)
 
-    Write-Output -InputObject "[$($VMName)]:: Waiting for name resolution"
+  Write-Output -InputObject "[$($VMName)]:: Waiting for name resolution"
 
-    while ((Test-NetConnection -ComputerName $domainName).PingSucceeded -eq $false) 
-    {
-        Start-Sleep -Seconds 1
-    }
+  while ((Test-NetConnection -ComputerName $domainName).PingSucceeded -eq $false) 
+  {
+    Start-Sleep -Seconds 1
+  }
 
-    Write-Output -InputObject "[$($VMName)]:: Configuring DHCP Server"    
-    Set-DhcpServerv4Binding -BindingState $true -InterfaceAlias Ethernet
-    Add-DhcpServerv4Scope -Name 'IPv4 Network' -StartRange "$($Subnet)10" -EndRange "$($Subnet)200" -SubnetMask 255.255.255.0
-    Set-DhcpServerv4OptionValue -OptionId 6 -value "$($Subnet)1"
-    Add-DhcpServerInDC -DnsName "$($env:computername).$($domainName)"
-    foreach($i in 1..99) 
-    {
-        $mac = '00-b5-5d-fe-f6-' + ($i % 100).ToString('00')
-        $ip = $Subnet + '1' + ($i % 100).ToString('00')
-        $desc = 'Container ' + $i.ToString()
-        $scopeID = $Subnet + '0'
-        Add-DhcpServerv4Reservation -IPAddress $ip -ClientId $mac -Description $desc -ScopeId $scopeID
-    }
+  Write-Output -InputObject "[$($VMName)]:: Configuring DHCP Server"    
+  Set-DhcpServerv4Binding -BindingState $True -InterfaceAlias Ethernet
+  Add-DhcpServerv4Scope -Name 'IPv4 Network' -StartRange "$($Subnet)10" -EndRange "$($Subnet)200" -SubnetMask 255.255.255.0
+  Set-DhcpServerv4OptionValue -OptionId 6 -value "$($Subnet)1"
+  Add-DhcpServerInDC -DnsName "$($env:computername).$($domainName)"
+  
+  foreach($i in 1..99) 
+  {
+    $mac = '00-b5-5d-fe-f6-' + ($i % 100).ToString('00')
+    $ip = $Subnet + '1' + ($i % 100).ToString('00')
+    $desc = 'Container ' + $i.ToString()
+    $scopeID = $Subnet + '0'
+    Add-DhcpServerv4Reservation -IPAddress $ip -ClientId $mac -Description $desc -ScopeId $scopeID
+  }
 } -ArgumentList $VMName, $domainName, $Subnet, $IPNumber
 
 Restart-DemoVM $VMName
@@ -652,41 +591,41 @@ $VMName = 'Domain Controller 2'
 $GuestOSName = 'DC2'
 $IPNumber = '2'
 
-Create-DemoVM $VMName $GuestOSName $IPNumber
+New-DemoVM $VMName $GuestOSName $IPNumber
 
 Invoke-Command -VMName $VMName -Credential $localCred {
-    param($VMName, $domainCred, $domainName)
-    Write-Output -InputObject "[$($VMName)]:: Installing AD"
-    $null = Install-WindowsFeature AD-Domain-Services -IncludeManagementTools
-    Write-Output -InputObject "[$($VMName)]:: Joining domain as `"$($env:computername)`""
-    while (!(Test-Connection -ComputerName $domainName -BufferSize 16 -Count 1 -Quiet -ea SilentlyContinue)) 
-    {
-        Start-Sleep -Seconds 1
-    }
-    do 
-    {
-        Add-Computer -DomainName $domainName -Credential $domainCred -ea SilentlyContinue
-    }
-    until ($?)
+  param($VMName, $domainCred, $domainName)
+  Write-Output -InputObject "[$($VMName)]:: Installing AD"
+  $null = Install-WindowsFeature AD-Domain-Services -IncludeManagementTools
+  Write-Output -InputObject "[$($VMName)]:: Joining domain as `"$($env:computername)`""
+  while (!(Test-Connection -ComputerName $domainName -BufferSize 16 -Count 1 -Quiet -ea SilentlyContinue)) 
+  {
+    Start-Sleep -Seconds 1
+  }
+  
+  do 
+  {
+    Add-Computer -DomainName $domainName -Credential $domainCred -ea SilentlyContinue
+  }
+  until ($?)
 } -ArgumentList $VMName, $domainCred, $domainName
 
 Restart-DemoVM $VMName
 Wait-PSDirect $VMName -cred $domainCred
 
 Invoke-Command -VMName $VMName -Credential $domainCred {
-    param($VMName, $domainName, $domainAdminPassword)
+  param($VMName, $domainName, $domainAdminPassword)
 
-    Write-Output -InputObject "[$($VMName)]:: Waiting for name resolution"
+  Write-Output -InputObject "[$($VMName)]:: Waiting for name resolution"
 
-    while ((Test-NetConnection -ComputerName $domainName).PingSucceeded -eq $false) 
-    {
-        Start-Sleep -Seconds 1
-    }
+  while ((Test-NetConnection -ComputerName $domainName).PingSucceeded -eq $false) 
+  {
+    Start-Sleep -Seconds 1
+  }
 
-    Write-Output -InputObject "[$($VMName)]:: Enabling Active Directory and promoting to domain controller"
+  Write-Output -InputObject "[$($VMName)]:: Enabling Active Directory and promoting to domain controller"
     
-    Install-ADDSDomainController -DomainName $domainName -InstallDNS -NoRebootOnCompletion `
-    -SafeModeAdministratorPassword (ConvertTo-SecureString -String $domainAdminPassword -AsPlainText -Force) -confirm:$false
+  Install-ADDSDomainController -DomainName $domainName -InstallDNS -NoRebootOnCompletion -SafeModeAdministratorPassword (ConvertTo-SecureString -String $domainAdminPassword -AsPlainText -Force) -confirm:$false
 } -ArgumentList $VMName, $domainName, $domainAdminPassword
 
 Restart-DemoVM $VMName
@@ -698,111 +637,79 @@ $IPNumber = '1'
 Wait-PSDirect $VMName -cred $domainCred
 
 Invoke-Command -VMName $VMName -Credential $domainCred {
-    param($VMName, $password)
+  param($VMName, $password)
 
-    Write-Output -InputObject "[$($VMName)]:: Creating user account for Dave"
-    do 
-    {
-        Start-Sleep -Seconds 5
-        New-ADUser `
-        -Name 'Dave' `
-        -SamAccountName  'Dave' `
-        -DisplayName 'Dave' `
-        -AccountPassword (ConvertTo-SecureString -String $password -AsPlainText -Force) `
-        -ChangePasswordAtLogon $false  `
-        -Enabled $true -ea 0
-    }
-    until ($?)
-    Add-ADGroupMember -Identity 'Domain Admins' -Members 'Dave'
+  Write-Output -InputObject "[$($VMName)]:: Creating user account for Dave"
+  do 
+  {
+    Start-Sleep -Seconds 5
+    New-ADUser -Name 'Dave' -SamAccountName  'Dave' -DisplayName 'Dave' -AccountPassword (ConvertTo-SecureString -String $password -AsPlainText -Force) -ChangePasswordAtLogon $false -Enabled $True -ea 0
+  }
+  until ($?)
+  Add-ADGroupMember -Identity 'Domain Admins' -Members 'Dave'
 } -ArgumentList $VMName, $domainAdminPassword
 
 $VMName = 'Management Console'
 $GuestOSName = 'Management'
 
-Create-DemoVM $VMName $GuestOSName
+New-DemoVM $VMName $GuestOSName
 
 Invoke-Command -VMName $VMName -Credential $localCred {
-    param($VMName, $domainCred, $domainName)
-    Write-Output -InputObject "[$($VMName)]:: Management tools"
-    $null = Install-WindowsFeature RSAT-Clustering, RSAT-Hyper-V-Tools
-    Write-Output -InputObject "[$($VMName)]:: Joining domain as `"$($env:computername)`""
-    while (!(Test-Connection -ComputerName $domainName -BufferSize 16 -Count 1 -Quiet -ea SilentlyContinue)) 
-    {
-        Start-Sleep -Seconds 1
-    }
-    do 
-    {
-        Add-Computer -DomainName $domainName -Credential $domainCred -ea SilentlyContinue
-    }
-    until ($?)
+  param($VMName, $domainCred, $domainName)
+  Write-Output -InputObject "[$($VMName)]:: Management tools"
+  $null = Install-WindowsFeature RSAT-Clustering, RSAT-Hyper-V-Tools
+  Write-Output -InputObject "[$($VMName)]:: Joining domain as `"$($env:computername)`""
+  while (!(Test-Connection -ComputerName $domainName -BufferSize 16 -Count 1 -Quiet -ea SilentlyContinue)) 
+  {
+    Start-Sleep -Seconds 1
+  }
+  
+  do 
+  {
+    Add-Computer -DomainName $domainName -Credential $domainCred -ea SilentlyContinue
+  }
+  until ($?)
 } -ArgumentList $VMName, $domainCred, $domainName
 
 Restart-DemoVM $VMName
-#Wait-PSDirect $VMName
 
-Invoke-DemoVMPrep 'S2DNode1' 'S2DNode1' -FullServer 
-Invoke-DemoVMPrep 'S2DNode2' 'S2DNode2' -FullServer 
-Invoke-DemoVMPrep 'S2DNode3' 'S2DNode3' -FullServer 
-Invoke-DemoVMPrep 'S2DNode4' 'S2DNode4' -FullServer 
-Invoke-DemoVMPrep 'S2DNode5' 'S2DNode5' -FullServer 
-Invoke-DemoVMPrep 'S2DNode6' 'S2DNode6' -FullServer 
-Invoke-DemoVMPrep 'S2DNode7' 'S2DNode7' -FullServer 
-Invoke-DemoVMPrep 'S2DNode8' 'S2DNode8' -FullServer 
-
+1..8 | ForEach-Object -Process {
+  Invoke-DemoVMPrep "S2DNode$_" "S2DNode$_" -FullServer
+}
 
 Wait-PSDirect 'S2DNode8' -cred $localCred
 
 $VMName = 'S2DNode1'
 $GuestOSName = 'S2Dnode1'
 
-Invoke-NodeStorageBuild 'S2DNode1' 'S2DNode1' 
-Invoke-NodeStorageBuild 'S2DNode2' 'S2DNode2' 
-Invoke-NodeStorageBuild 'S2DNode3' 'S2DNode3' 
-Invoke-NodeStorageBuild 'S2DNode4' 'S2DNode4' 
-Invoke-NodeStorageBuild 'S2DNode5' 'S2DNode5' 
-Invoke-NodeStorageBuild 'S2DNode6' 'S2DNode6' 
-Invoke-NodeStorageBuild 'S2DNode7' 'S2DNode7' 
-Invoke-NodeStorageBuild 'S2DNode8' 'S2DNode8' 
-
-
+1..8 | ForEach-Object -Process {
+  Invoke-NodeStorageBuild "S2DNode$_" "S2DNode$_"
+}
 
 Wait-PSDirect 'S2DNode8' -cred $domainCred
 
 Invoke-Command -VMName 'Management Console' -Credential $domainCred {
-    param ($domainName)
-    do 
-    {
-        New-Cluster -Name S2DCluster -Node S2DNode1, S2DNode2, S2DNode3, S2DNode4,S2DNode5,S2DNode6,S2DNode7,S2DNode8 -NoStorage
-    }
-    until ($?)
-    while (!(Test-Connection -ComputerName "S2DCluster.$($domainName)" -BufferSize 16 -Count 1 -Quiet -ea SilentlyContinue)) 
-    {
-        ipconfig.exe /flushdns
-        Start-Sleep -Seconds 1
-    }
-    #Enable-ClusterStorageSpacesDirect -Cluster "S2DCluster.$($domainName)"
-    #Add-ClusterScaleOutFileServerRole -name S2DFileServer -cluster "S2DCluster.$($domainName)"
+  param ($domainName)
+  do 
+  {
+    New-Cluster -Name S2DCluster -Node S2DNode1, S2DNode2, S2DNode3, S2DNode4, S2DNode5, S2DNode6, S2DNode7, S2DNode8 -NoStorage
+  }
+  until ($?)
+  
+  while (!(Test-Connection -ComputerName "S2DCluster.$($domainName)" -BufferSize 16 -Count 1 -Quiet -ea SilentlyContinue)) 
+  {
+    ipconfig.exe /flushdns
+    Start-Sleep -Seconds 1
+  }
 } -ArgumentList $domainName
 
 Invoke-Command -VMName 'S2DNode1' -Credential $domainCred {
-    param ($domainName)
-    #New-StoragePool -StorageSubSystemName "S2DCluster.$($domainName)" -FriendlyName S2DPool -WriteCacheSizeDefault 0 -ProvisioningTypeDefault Fixed -ResiliencySettingNameDefault Mirror -PhysicalDisk (Get-StorageSubSystem  -Name "S2DCluster.$($domainName)" | Get-PhysicalDisk)
-    #New-Volume -StoragePoolFriendlyName S2DPool -FriendlyName S2DDisk -PhysicalDiskRedundancy 2 -FileSystem CSVFS_REFS -Size 500GB
-    #updated from MSFT TP5 notes
+  param ($domainName)
+  Enable-ClusterStorageSpacesDirect -PoolFriendlyName S2DPool -confirm:$false
 
-   # The Cmdlet changed for RTM - Enable-ClusterS2D -CacheMode Disabled -AutoConfig:0 -SkipEligibilityChecks -confirm:$false
-   #This step can take a little while espeically if you are adding a lot of nodes and disks
-    Enable-ClusterStorageSpacesDirect -PoolFriendlyName S2DPool -confirm:$False
-
-    #Create storage pool and set media type to HDD
-    #New-StoragePool -StorageSubSystemFriendlyName *Cluster* -FriendlyName S2D -ProvisioningTypeDefault Fixed -PhysicalDisk (Get-PhysicalDisk | Where-Object -Property CanPool -EQ -Value $true)
-
-    #Create a volume
-    #This will match the configuration that was done in the book
-
-    New-Volume -StoragePoolFriendlyName S2DPool -FriendlyName Mirror-2Way -FileSystem CSVFS_REFS -Size 200GB -PhysicalDiskRedundancy 1 
-    New-Volume -StoragePoolFriendlyName S2DPool -FriendlyName Mirror-3Way -FileSystem CSVFS_REFS -Size 200GB -PhysicalDiskRedundancy 2 
-
+  # This will match the configuration that was done in the book
+  New-Volume -StoragePoolFriendlyName S2DPool -FriendlyName Mirror-2Way -FileSystem CSVFS_REFS -Size 200GB -PhysicalDiskRedundancy 1 
+  New-Volume -StoragePoolFriendlyName S2DPool -FriendlyName Mirror-3Way -FileSystem CSVFS_REFS -Size 200GB -PhysicalDiskRedundancy 2
 } -ArgumentList $domainName
 
 Write-Log 'Done' 'Done!'


### PR DESCRIPTION
- Ran auto-refactor to fix whitespace, positional param issues, and others
- Re-did Write-Log and removed other instances of Write-Host so this can be run unattended
- Changed time output in Write-Log to include seconds
- Removed backticks where found, replaced with other line break methods
- Renamed "$path" param in Confirm-Path
- Re-did Wait-Sleep to eliminate useless params
- Added -Force flag to remove-item command in Clear-File
- Removed 'return' in Get-UnattendChunk because PowerShell uses it differently
- Fixed New-UnattendFile to make 3x fewer Get-UnattendChunk calls
- Removed vague comments and commented lines of code that are no longer used
- Re-did Invoke-DemoVMPrep to make a more readable decision depending if FullServer switch is passed or not
- Renamed Create-DemoVM to New-DemoVM to use an approved verb instead
- Re-did Invoke-NodeStorageBuild to 12x fewer Invoke-Command commands to set net adapter settings, replaced ping.exe references with Test-Connection
- Removed real keys from $WindowsKey variable assignment, added a line to throw an error that a user will see and remove when they actually do add their own value for $WindowsKey
- Added foreach-object loop to create S2D nodes instead of 8 lines of repetitive code
- Added foreach-object loop to invoke-nodestoragebuild instead of 8 lines of repetitive code